### PR TITLE
Update test-yaml.js

### DIFF
--- a/site/test-yaml.js
+++ b/site/test-yaml.js
@@ -176,7 +176,8 @@ status(__dirname)
             (f) =>
                 f.path.indexOf(".yml") === -1 &&
                 f.path.indexOf("package.json") === -1 &&
-                f.path.indexOf("package-lock.json") === -1
+                f.path.indexOf("package-lock.json") === -1 &&
+                f.path.indexOf("resumes.json") === -1
         );
         //const nonYMLFiles = [];
         if (nonYMLFiles.length > 0) {


### PR DESCRIPTION
So that it stops throwing an error any time anyone tries to commit their profile, because the build script rebuilds resumes.json each time.